### PR TITLE
Comply with the AutoRest Swagger schema

### DIFF
--- a/lib/class-wp-rest-swagger-controller.php
+++ b/lib/class-wp-rest-swagger-controller.php
@@ -48,6 +48,11 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 
 		return $rootURL;
 	}
+	
+	private function compose_operation_name($carry, $part) {
+		$carry .= ucfirst(strtolower($part));
+		return $carry;
+	}
 
 	/**
 	 * Retrieve custom swagger object.
@@ -287,12 +292,12 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 						);
 					}
 					
-					
+					$operationId = ucfirst(strtolower($methodName)) . array_reduce(explode('/', preg_replace("/{(\w+)}/", 'by/${1}', $endpointName)), array($this, "compose_operation_name"));
 					$swagger['paths'][$endpointName][strtolower($methodName)] = array(
 						'parameters'=>$parameters
 						,'security'=>$security
 						,'responses'=>$responses
-						
+						,'operationId'=>$operationId
 					);
 					
 				}

--- a/lib/class-wp-rest-swagger-controller.php
+++ b/lib/class-wp-rest-swagger-controller.php
@@ -317,6 +317,8 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 						
 			if(!empty($prop['properties'])){
 				$prop = $this->schemaIntoDefinition($prop);
+			} else if(isset($prop['properties'])){
+				$prop['properties'] = new stdClass();
 			}
 			
 			//-- Changes by Richi


### PR DESCRIPTION
These two changes are necessary to be able to generate the Swagger client through the [AutoRest tool](https://github.com/Azure/autorest)