### PR TITLE
Fix array/object types

### DIFF
--- a/lib/class-wp-rest-swagger-controller.php
+++ b/lib/class-wp-rest-swagger-controller.php
@@ -247,18 +247,20 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 						}
 						if(!empty($pdetails['type'])){
 							if($pdetails['type']=='array'){
-								$parameter['type']=$pdetails['type'];
-								$parameter['items']=array(
-									'type'=> $pdetails['items']['type'],
-									'properties'=> $pdetails['items']['properties']
-								);
+								if($pdetails['items']) {
+									$parameter['items']=$pdetails['items'];
+								} else {
+									$parameter['items']=array('type'=>'string');
+								}
 							}elseif($pdetails['type']=='object'){
 								$parameter['type']=$pdetails['type'];
-								$parameter['items']=array(
-									'type'=> $pdetails['items']['type'],
-									'properties'=> $pdetails['items']['properties']
-								);
-							
+								if($pdetails['items']) {
+									$parameter['items']=$pdetails['items'];
+								}else if ($pdetails['properties']) {
+									$parameter['properties']=$pdetails['properties']['rendered'];
+								}else {
+									$parameter['items']=array('type'=>'string');
+								}
 							}elseif($pdetails['type']=='date-time'){
 								$parameter['type']='string';
 								$parameter['format']='date-time';
@@ -350,11 +352,8 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 //--
 
 			
-			if($prop['type']=='array'){
-				$prop['items'] = array(
-					'type'=> $prop['items']['type'],
-					'properties'=> $prop['items']['properties']
-				);
+			if($prop['type']=='array' && !$prop['items']){
+				$prop['items']=array('type'=>'string');
 			}else			
 			if($prop['type']=='date-time'){
 				$prop['type']='string';

--- a/lib/class-wp-rest-swagger-controller.php
+++ b/lib/class-wp-rest-swagger-controller.php
@@ -247,6 +247,7 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 						}
 						if(!empty($pdetails['type'])){
 							if($pdetails['type']=='array'){
+								$parameter['type']=$pdetails['type'];
 								if($pdetails['items']) {
 									$parameter['items']=$pdetails['items'];
 								} else {
@@ -254,12 +255,10 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 								}
 							}elseif($pdetails['type']=='object'){
 								$parameter['type']=$pdetails['type'];
-								if($pdetails['items']) {
-									$parameter['items']=$pdetails['items'];
-								}else if ($pdetails['properties']) {
-									$parameter['properties']=$pdetails['properties']['rendered'];
+								if (isset($pdetails['properties'])) {
+									$parameter['properties']=$pdetails['properties'];
 								}else {
-									$parameter['items']=array('type'=>'string');
+									$parameter['properties']=array('type'=>'string');
 								}
 							}elseif($pdetails['type']=='date-time'){
 								$parameter['type']='string';
@@ -351,13 +350,14 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 			}
 //--
 
-			
-			if($prop['type']=='array' && !$prop['items']){
-				$prop['items']=array('type'=>'string');
-			}else			
-			if($prop['type']=='date-time'){
-				$prop['type']='string';
-				$prop['format']='date-time';
+			if (array_key_exists('type', $prop)) {
+				if($prop['type']=='array' && !array_key_exists('items', $prop)){
+					$prop['items']=array('type'=>'string');
+				}else			
+				if($prop['type']=='date-time'){
+					$prop['type']='string';
+					$prop['format']='date-time';
+				}
 			}
 //			else if(!empty($prop['context']) && $prop['format']!='date-time'){
 //				//$prop['enum']=$prop['context'];

--- a/lib/class-wp-rest-swagger-controller.php
+++ b/lib/class-wp-rest-swagger-controller.php
@@ -248,9 +248,16 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 						if(!empty($pdetails['type'])){
 							if($pdetails['type']=='array'){
 								$parameter['type']=$pdetails['type'];
-								$parameter['items']=array('type'=>'string');
+								$parameter['items']=array(
+									'type'=> $pdetails['items']['type'],
+									'properties'=> $pdetails['items']['properties']
+								);
 							}elseif($pdetails['type']=='object'){
-								$parameter['type']='string';
+								$parameter['type']=$pdetails['type'];
+								$parameter['items']=array(
+									'type'=> $pdetails['items']['type'],
+									'properties'=> $pdetails['items']['properties']
+								);
 							
 							}elseif($pdetails['type']=='date-time'){
 								$parameter['type']='string';
@@ -344,7 +351,10 @@ class WP_REST_Swagger_Controller extends WP_REST_Controller {
 
 			
 			if($prop['type']=='array'){
-				$prop['items']=array('type'=>'string');
+				$prop['items'] = array(
+					'type'=> $prop['items']['type'],
+					'properties'=> $prop['items']['properties']
+				);
 			}else			
 			if($prop['type']=='date-time'){
 				$prop['type']='string';


### PR DESCRIPTION
Previously all array and object types defaulted to strings. This should instead look at the array/object item's type and (if the item is an object) all the properties within that item. I've tested it against two levels deep of arrays of objects and it seems to work correctly now.